### PR TITLE
momentの不要なlocale削除

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "css-loader": "6.5.1",
     "html-webpack-plugin": "5.5.0",
     "mini-css-extract-plugin": "2.4.5",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "postcss": "8.3.11",
     "postcss-import": "14.0.2",
     "postcss-loader": "6.2.0",

--- a/client/src/components/foundation/CoveredImage/CoveredImage.jsx
+++ b/client/src/components/foundation/CoveredImage/CoveredImage.jsx
@@ -11,7 +11,7 @@ import { fetchBinary } from '../../../utils/fetchers';
  * @property {string} alt
  * @property {string} src
  */
-
+// TODOアスペクト比さえちゃんとすれば良さそう
 /**
  * アスペクト比を維持したまま、要素のコンテンツボックス全体を埋めるように画像を拡大縮小します
  * @type {React.VFC<Props>}

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const webpack = require('webpack');
+const MomentLocalesPlugin = require("moment-locales-webpack-plugin");
 
 const SRC_PATH = path.resolve(__dirname, './src');
 const PUBLIC_PATH = path.resolve(__dirname, '../public');
@@ -74,6 +75,7 @@ const config = {
       inject: false,
       template: path.resolve(SRC_PATH, './index.html'),
     }),
+    new MomentLocalesPlugin({ localesToKeep: ["ja"] }),
   ],
   resolve: {
     extensions: ['.js', '.jsx'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3878,6 +3878,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.flattendeep@^4.0.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -4091,6 +4096,13 @@ modern-normalize@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
   integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
+
+moment-locales-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
+  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment-timezone@^0.5.31:
   version "0.5.34"


### PR DESCRIPTION
script/vendor~のバンドルサイズが3.8MBから2.72MBになった(Parsedの時)